### PR TITLE
Add KOI to inform extensions which CSS framework is being used

### DIFF
--- a/koi.json
+++ b/koi.json
@@ -1,0 +1,9 @@
+{
+	"instructions": {
+		"purpose": "This file is placed in the folder of DNN skins/themes. It tells the Koi system, what the primary CSS framework is for the themes in this folder.",
+		"discoverMore": "https://connect-koi.net/"
+	},
+	"default": {
+		"cssFramework": "tlw2"
+	}
+}


### PR DESCRIPTION
## Related to Issue
Resolves #1 

## Description
Adds `koi.json` to inform other extensions which CSS framework (in this case Tailwind 2) is being used in the theme.

## How Has This Been Tested?
Local development environment.

## Screenshots (if appropriate):
n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
