### PR TITLE
Refactor `paths` JSON to be housed outside `gulpfile.ts`

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -1,19 +1,9 @@
 import gulp from 'gulp';
 
 var notify          = require('gulp-notify'),
+    paths           = require('./project-paths.json'),
     postcss         = require('gulp-postcss'),
     rename          = require('gulp-rename');
-
-var paths = {
-    fonts: {
-        src: './src/fonts/*',
-        dest: './dist/fonts/'
-    },
-    styles: {
-        src: './src/css/styles.css',
-        dest: './dist/css/'
-    }
-};
 
 /*------------------------------------------------------*/
 /* INIT TASKS ------------------------------------------*/

--- a/project-paths.json
+++ b/project-paths.json
@@ -1,0 +1,10 @@
+{
+    "fonts": {
+        "src": "./src/fonts/*",
+        "dest": "./dist/fonts/"
+    },
+    "styles": {
+        "src": "./src/css/styles.css",
+        "dest": "./dist/css/"
+    }
+}


### PR DESCRIPTION
## Related to Issue
Resolves #21 

## Description
`paths` are now stored in `project-paths.json`.

## How Has This Been Tested?
* Local dev environment.
* Tested `gulp build` to ensure everything still worked as expected.

## Screenshots (if appropriate):
n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
