### PR TITLE
Fix export for `fontsInit` task

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -51,6 +51,7 @@ var build = gulp.series(init, styles);
 /*------------------------------------------------------*/
 /* EXPORT TASKS ----------------------------------------*/
 /*------------------------------------------------------*/
+exports.fontsInit = fontsInit;
 exports.styles = styles;
 exports.init = init;
 exports.build = build;


### PR DESCRIPTION
## Description
An export was missing for the `fontsInit` task and has now been added.

## How Has This Been Tested?
* Tested gulp task in local development environment.

## Screenshots (if appropriate):
n/a

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
