### PR TITLE
Add FontAwesome 6

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -18,6 +18,28 @@ function fontsInit() {
           log(fileCount, 'font file(s) distributed!');
         });
 }
+
+// Copy fontawesome-free fonts from node_modules to dist/fonts
+function faFontsInit() {
+  var fileCount = 0;
+  return gulp.src(paths.faFonts.src)
+    .pipe(gulp.dest(paths.faFonts.dest))
+    .on('data', function() { fileCount += 1; })
+    .on('end', function() {
+      log(fileCount, 'webfont file(s) distributed!');
+    });
+}
+
+// Copy fontawesome-free CSS from node_modules to dist/css
+function faCssInit() {
+  var fileCount = 0;
+  return gulp.src(paths.faCss.src)
+    .pipe(gulp.dest(paths.faCss.dest))
+    .on('data', function() { fileCount += 1; })
+    .on('end', function() {
+      log(fileCount, 'CSS file(s) distributed!');
+    });
+}
 /*------------------------------------------------------*/
 /* END INIT TASKS --------------------------------------*/
 /*------------------------------------------------------*/
@@ -47,7 +69,7 @@ function styles() {
 /* DEV TASKS -------------------------------------------*/
 /*------------------------------------------------------*/
 // gulp init
-var init = gulp.series(fontsInit);
+var init = gulp.series(fontsInit, faFontsInit, faCssInit);
 
 // gulp build
 var build = gulp.series(init, styles);
@@ -60,6 +82,8 @@ var build = gulp.series(init, styles);
 /* EXPORT TASKS ----------------------------------------*/
 /*------------------------------------------------------*/
 exports.fontsInit = fontsInit;
+exports.faFontsInit = faFontsInit;
+exports.faCssInit = faCssInit;
 exports.styles = styles;
 exports.init = init;
 exports.build = build;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@tailwindcss/typography": "^0.5.2"
       },
       "devDependencies": {
+        "@fortawesome/fontawesome-free": "^6.1.1",
         "@types/gulp": "^4.0.9",
         "autoprefixer": "^10.4.5",
         "cssnano": "^5.0.8",
@@ -47,6 +48,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.1.1.tgz",
+      "integrity": "sha512-J/3yg2AIXc9wznaVqpHVX3Wa5jwKovVF0AMYSnbmcXTiL3PpRPfF58pzWucCwEiCJBp+hCNRLWClTomD8SseKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -6012,6 +6023,12 @@
       "requires": {
         "@cspotcode/source-map-consumer": "0.8.0"
       }
+    },
+    "@fortawesome/fontawesome-free": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.1.1.tgz",
+      "integrity": "sha512-J/3yg2AIXc9wznaVqpHVX3Wa5jwKovVF0AMYSnbmcXTiL3PpRPfF58pzWucCwEiCJBp+hCNRLWClTomD8SseKg==",
+      "dev": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tailwindcss/typography": "^0.5.2"
   },
   "devDependencies": {
+    "@fortawesome/fontawesome-free": "^6.1.1",
     "@types/gulp": "^4.0.9",
     "autoprefixer": "^10.4.5",
     "cssnano": "^5.0.8",

--- a/partials/_header.ascx
+++ b/partials/_header.ascx
@@ -5,7 +5,7 @@
         <div class="flex list-unstyled align-middle mx-4">
           <div class="py-4"><dnn:Login runat="server" id="dnnLogin" /></div>
           <div class="py-4"><dnn:User runat="server" id="dnnUser" /></div>
-          <div class="py-4"><dnn:Search runat="server" id="dnnSearch" ShowSite="false" ShowWeb="false" Submit="<i class='fas fa-search'></i>" /></div>
+          <div class="py-4"><dnn:Search runat="server" id="dnnSearch" ShowSite="false" ShowWeb="false" Submit="<i class='fa-solid fa-magnifying-glass'></i>" /></div>
           <div class="py-4" style="display:none;"><dnn:Language runat="server" id="dnnLanguage" ShowMenu="false" ShowLinks="false" /></div>
         </div>
       </div>

--- a/partials/_includes.ascx
+++ b/partials/_includes.ascx
@@ -5,7 +5,6 @@
 <dnn:DnnCssInclude runat="server" FilePath="dist/css/styles.min.css" Priority="110" PathNameAlias="SkinPath" />
 
 <dnn:DnnJsInclude runat="server" FilePath="dist/js/jquery.slimmenu.min.js" ForceProvider="DnnFormBottomProvider" Priority="100" PathNameAlias="SkinPath" />
-<dnn:DnnJsInclude runat="server" FilePath="dist/js/bootstrap.bundle.min.js" ForceProvider="DnnFormBottomProvider" Priority="110" PathNameAlias="SkinPath" />
 <dnn:DnnJsInclude runat="server" FilePath="dist/js/custom.min.js" ForceProvider="DnnFormBottomProvider" Priority="120" PathNameAlias="SkinPath" />
 <dnn:DnnJsInclude runat="server" FilePath="dist/js/modernizr-custom.min.js" ForceProvider="DnnFormBottomProvider" Priority="130" PathNameAlias="SkinPath" />
 
@@ -27,6 +26,7 @@
         var types = new Dictionary<string, string>();
         types.Add("woff2", "font/woff2");
         types.Add("woff", "font/woff");
+        types.Add("ttf", "font/ttf");
 
         var defaultPage = (CDefault)this.Page;
 
@@ -34,6 +34,14 @@
         {
             foreach (var font in fonts)
             {
+                if (font.Contains("dist/webfonts") && type.Key == "woff")
+                {
+                    continue;
+                }
+                if (font.Contains("dist/fonts") && type.Key == "ttf")
+                {
+                    continue;
+                }
                 var fontLink = new HtmlLink();
                 fontLink.Attributes.Add("rel", "preload");
                 fontLink.Attributes.Add("as", "font");

--- a/project-paths.json
+++ b/project-paths.json
@@ -3,6 +3,14 @@
         "src": "./src/fonts/*",
         "dest": "./dist/fonts/"
     },
+    "faFonts": {
+        "src": "./node_modules/@fortawesome/fontawesome-free/webfonts/*",
+        "dest": "./dist/webfonts/"
+    },
+    "faCss": {
+        "src": "./node_modules/@fortawesome/fontawesome-free/css/all.min.css",
+        "dest": "./dist/css/"
+    },
     "styles": {
         "src": "./src/css/styles.css",
         "dest": "./dist/css/"


### PR DESCRIPTION
## Related to Issue
Resolves #26 

## Description
This PR adds FontAwesome 6.1.1.  FontAwesome 6 brings some changes to the webfonts used.  Now, only `woff2` and `ttf` fonts are distributed.  This required some changes to the way the fonts are preloaded in `_includes.ascx`.

## How Has This Been Tested?
* Local development environment
* Tested gulp additions to ensure the proper fonts are distributed.
* Ensured preload code was rewritten to handle the variations between font and webfont file types.

## Screenshots (if appropriate):
n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
