### PR TITLE
Add `gulp manifest` task

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -4,6 +4,7 @@ var log             = require('fancy-log'),
     paths           = require('./project-paths.json'),
     postcss         = require('gulp-postcss'),
     rename          = require('gulp-rename'),
+    replace         = require('gulp-replace'),
     details         = require('./project-details.json'),
     project         = details.project,
     version         = details.version,
@@ -74,13 +75,42 @@ function styles() {
 
 
 /*------------------------------------------------------*/
+/* DNN TASKS -------------------------------------------*/
+/*------------------------------------------------------*/
+// Update manifest.dnn
+function manifest() {
+  var fileCount = 0;
+  return gulp.src(paths.manifest.src)
+    .pipe(replace(/\<package name\=\"(.*?)(?=\")/, '<package name="' + company + '.' + project))
+    .pipe(replace(/type\=\"Skin\" version\=\"(.*?)(?=\")/, 'type="Skin" version="' + version))
+    .pipe(replace(/\<friendlyName\>(.*?)(?=\<)/, '<friendlyName>' + project))
+    .pipe(replace(/\<description\>(.*?)(?=\<)/, '<description>' + description))
+    .pipe(replace(/\<name\>(.*?)(?=\<)/, '<name>' + author))
+    .pipe(replace(/\<organization\>(.*?)(?=\<)/, '<organization>' + company))
+    .pipe(replace(/\<url\>(.*?)(?=\<)/, '<url>' + url))
+    .pipe(replace(/\<email\>(.*?)(?=\<)/, '<email>' + email))
+    .pipe(replace(/\<skinName\>(.*?)(?=\<)/, '<skinName>' + project))
+    .pipe(replace(/(\\Skins\\)(.*?)(?=\\)/g, '\\Skins\\' + project))
+    .pipe(replace(/(\\Containers\\)(.*?)(?=\\)/g, '\\Containers\\' + project))
+    .pipe(gulp.dest(paths.manifest.dest))
+    .on('data', function() { fileCount += 1; })
+    .on('end', function() {
+      log(fileCount, 'manifest file(s) updated and distributed!');
+    });
+}
+/*------------------------------------------------------*/
+/* END DNN TASKS ---------------------------------------*/
+/*------------------------------------------------------*/
+
+
+/*------------------------------------------------------*/
 /* DEV TASKS -------------------------------------------*/
 /*------------------------------------------------------*/
 // gulp init
 var init = gulp.series(fontsInit, faFontsInit, faCssInit);
 
 // gulp build
-var build = gulp.series(init, styles);
+var build = gulp.series(init, styles, manifest);
 /*------------------------------------------------------*/
 /* END DEV TASKS ---------------------------------------*/
 /*------------------------------------------------------*/
@@ -93,6 +123,7 @@ exports.fontsInit = fontsInit;
 exports.faFontsInit = faFontsInit;
 exports.faCssInit = faCssInit;
 exports.styles = styles;
+exports.manifest = manifest;
 exports.init = init;
 exports.build = build;
 

--- a/manifest.dnn
+++ b/manifest.dnn
@@ -1,8 +1,8 @@
 <dotnetnuke type="Package" version="9.0">
   <packages>
-    <package name="nvisionative.nvQuickTheme.Tailwind" type="Skin" version="1.0.0">
-      <friendlyName>nvQuickTheme (Tailwind)</friendlyName>
-      <description>A DNN Theme Dev Framework Using Tailwind</description>
+    <package name="nvisionative.nvQuickTheme-Tailwind" type="Skin" version="1.0.0">
+      <friendlyName>nvQuickTheme-Tailwind</friendlyName>
+      <description>A DNN Theme Dev Framework based on Tailwind CSS</description>
       <iconFile>MyIcon.png</iconFile>
       <owner>
         <name>David Poindexter</name>

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "gulp": "^4.0.2",
         "gulp-postcss": "^9.0.1",
         "gulp-rename": "^2.0.0",
+        "gulp-replace": "^1.1.3",
         "postcss-import": "^14.1.0",
         "tailwindcss": "^3.0.24",
         "ts-node": "^10.4.0",
@@ -686,6 +687,18 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/binaryextensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.3.0.tgz",
+      "integrity": "sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/boolbase": {
@@ -1611,6 +1624,15 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/expand-brackets": {
@@ -2619,6 +2641,28 @@
         "node": ">=4"
       }
     },
+    "node_modules/gulp-replace": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/gulp-replace/-/gulp-replace-1.1.3.tgz",
+      "integrity": "sha512-HcPHpWY4XdF8zxYkDODHnG2+7a3nD/Y8Mfu3aBgMiCFDW3X2GiOKXllsAmILcxe3KZT2BXoN18WrpEFm48KfLQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^14.14.41",
+        "@types/vinyl": "^2.0.4",
+        "istextorbinary": "^3.0.0",
+        "replacestream": "^4.0.3",
+        "yargs-parser": ">=5.0.0-security.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gulp-replace/node_modules/@types/node": {
+      "version": "14.18.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.16.tgz",
+      "integrity": "sha512-X3bUMdK/VmvrWdoTkz+VCn6nwKwrKCFTHtqwBIaQJNx4RUIBBUFXM00bqPz/DsDd+Icjmzm6/tyYZzeGVqb6/Q==",
+      "dev": true
+    },
     "node_modules/gulp/node_modules/fancy-log": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
@@ -3088,6 +3132,22 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/istextorbinary": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-3.3.0.tgz",
+      "integrity": "sha512-Tvq1W6NAcZeJ8op+Hq7tdZ434rqnMx4CCZ7H0ff83uEloDvVbqAwaMTZcafKGJT0VHkYzuXUiCY4hlXQg6WfoQ==",
+      "dev": true,
+      "dependencies": {
+        "binaryextensions": "^2.2.0",
+        "textextensions": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -3652,6 +3712,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4767,6 +4836,17 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/replacestream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.3.tgz",
+      "integrity": "sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.3",
+        "object-assign": "^4.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5390,6 +5470,18 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/textextensions": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-3.3.0.tgz",
+      "integrity": "sha512-mk82dS8eRABNbeVJrEiN5/UMSCliINAuz8mkUwH4SwslkNP//gbEzlWNS5au0z5Dpx40SQxzqZevZkn+WYJ9Dw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/through2": {
@@ -6523,6 +6615,12 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
+    "binaryextensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.3.0.tgz",
+      "integrity": "sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg==",
+      "dev": true
+    },
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -7248,6 +7346,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "expand-brackets": {
@@ -8108,6 +8212,27 @@
       "integrity": "sha512-97Vba4KBzbYmR5VBs9mWmK+HwIf5mj+/zioxfZhOKeXtx5ZjBk57KFlePf5nxq9QsTtFl0ejnHE3zTC9MHXqyQ==",
       "dev": true
     },
+    "gulp-replace": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/gulp-replace/-/gulp-replace-1.1.3.tgz",
+      "integrity": "sha512-HcPHpWY4XdF8zxYkDODHnG2+7a3nD/Y8Mfu3aBgMiCFDW3X2GiOKXllsAmILcxe3KZT2BXoN18WrpEFm48KfLQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "^14.14.41",
+        "@types/vinyl": "^2.0.4",
+        "istextorbinary": "^3.0.0",
+        "replacestream": "^4.0.3",
+        "yargs-parser": ">=5.0.0-security.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.18.16",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.16.tgz",
+          "integrity": "sha512-X3bUMdK/VmvrWdoTkz+VCn6nwKwrKCFTHtqwBIaQJNx4RUIBBUFXM00bqPz/DsDd+Icjmzm6/tyYZzeGVqb6/Q==",
+          "dev": true
+        }
+      }
+    },
     "gulplog": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
@@ -8439,6 +8564,16 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "istextorbinary": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-3.3.0.tgz",
+      "integrity": "sha512-Tvq1W6NAcZeJ8op+Hq7tdZ434rqnMx4CCZ7H0ff83uEloDvVbqAwaMTZcafKGJT0VHkYzuXUiCY4hlXQg6WfoQ==",
+      "dev": true,
+      "requires": {
+        "binaryextensions": "^2.2.0",
+        "textextensions": "^3.2.0"
+      }
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -8895,6 +9030,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-copy": {
@@ -9655,6 +9796,17 @@
         "remove-trailing-separator": "^1.1.0"
       }
     },
+    "replacestream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.3.tgz",
+      "integrity": "sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.3",
+        "object-assign": "^4.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -10142,6 +10294,12 @@
         "quick-lru": "^5.1.1",
         "resolve": "^1.22.0"
       }
+    },
+    "textextensions": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-3.3.0.tgz",
+      "integrity": "sha512-mk82dS8eRABNbeVJrEiN5/UMSCliINAuz8mkUwH4SwslkNP//gbEzlWNS5au0z5Dpx40SQxzqZevZkn+WYJ9Dw==",
+      "dev": true
     },
     "through2": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gulp": "^4.0.2",
     "gulp-postcss": "^9.0.1",
     "gulp-rename": "^2.0.0",
+    "gulp-replace": "^1.1.3",
     "postcss-import": "^14.1.0",
     "tailwindcss": "^3.0.24",
     "ts-node": "^10.4.0",

--- a/project-paths.json
+++ b/project-paths.json
@@ -14,5 +14,9 @@
     "styles": {
         "src": "./src/css/styles.css",
         "dest": "./dist/css/"
+    },
+    "manifest": {
+        "src": "./manifest.dnn",
+        "dest": "./"
     }
 }


### PR DESCRIPTION
## Related to Issue
Resolves #29 

## Description
This PR adds a gulp task for automated manipulation of the manifest file.

## How Has This Been Tested?
* Tested `gulp manifest` in local development environment
* Also tested `gulp build` (which now includes the `manifest` task

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4568451/167272990-ecc8d3a6-ea37-4a9e-b5b3-7864def47b2f.png)

![image](https://user-images.githubusercontent.com/4568451/167273013-f7280565-896b-424d-bbc5-2f577c42f76c.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
